### PR TITLE
Resolve/Workaround Janino RT compiler issues

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,12 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="active-configuration" value="LOCAL_FILE:$PROJECT_DIR$/checkstyle.xml:Project Checkstyle" />
+        <entry key="active-configuration-0" value="LOCAL_FILE:/home/idans/IdeaProjects/dremio-udf-gis/checkstyle.xml:Project Checkstyle" />
         <entry key="checkstyle-version" value="9.3" />
         <entry key="copy-libs" value="false" />
-        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
-        <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
-        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/checkstyle.xml:Project Checkstyle" />
+        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks;All" />
+        <entry key="location-1" value="BUNDLED:(bundled):Google Checks;All" />
+        <entry key="location-2" value="LOCAL_FILE:$PROJECT_DIR$/checkstyle.xml:Project Checkstyle;All" />
         <entry key="property-2.config_loc" value="" />
         <entry key="scan-before-checkin" value="false" />
         <entry key="scanscope" value="JavaOnly" />

--- a/README.MD
+++ b/README.MD
@@ -24,6 +24,7 @@ Derived from:
 - Take the shaded jar for the desired version and place inside your Dremio installation (`$DREMIO_HOME/jars/3rdparty`)
 - Restart your Dremio server(s)
 - Rejoice!
+- See the [Cheat Sheet](https://github.com/sheinbergon/dremio-udf-gis/wiki/GIS-Functions-Cheat-Sheet) for detailed usage instructions
 
 ### Usage Notes
 As opposed to PostGIS, Dremio is only a query engine based on existing/projected data sources/lakes.

--- a/README.MD
+++ b/README.MD
@@ -14,7 +14,7 @@ Derived from:
 
 ### What you get
 - Widespread OGC implementation for SQL (adheres to PostGIS standards)
-  - Supported input formats: `WKT`
+  - Supported input formats: `WKT`, `WKB`
   - Supported output formats: `WKT`, `JSON`, `GeoJSON` 
 - Easily installable Maven-Central/Github artifacts shaded jar artifact  
 - Dremio CE version compatibility (new versions will be released with each community edition) 
@@ -29,14 +29,14 @@ Derived from:
 As opposed to PostGIS, Dremio is only a query engine based on existing/projected data sources/lakes.
 That means that:
 - `Geometry` is not a supported data type, meaning you can't query it directly
-- Metadata information, such as `SRID`, cannot be tied to the geometry data.  
+- Metadata information, such as `SRID`, **currently** cannot be tied to the geometry data.  
   To be more specific, this implementation is tied to the ESRI geometry API serialization capabilities.
 
-In order to successfully use the provided functionality, you must first decode data to an `OGCGeometry` type, using `ST_GeomFromText`.
-This library uses Dremios' Arrow buffers (`ArrowBuf`) to maintain geometry data in binary (`WKB`) format (for performance and efficiency) when
+In order to successfully use the provided functionality, you must first decode you geometry data either from `WKT` (using `ST_GeomFromText`) 
+or from `WKB` (using ST_GeomFromWKB). This library uses Dremios' Arrow buffers (`ArrowBuf`) to maintain geometry data in binary (`WKB`) format (for performance and efficiency) when
 interchanging it between GIS functions, which is of course undecipherable for the naked eye.  
 
-In order to resolve Data back to human readable format (`WKT`), use `ST_AsText`/`ST_AsGeoJson`
+In order to resolve Data back to human-readable format (`WKT`), use `ST_AsText`/`ST_AsGeoJson`
 
 Example:
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <esri-geometry-api.version>2.2.4</esri-geometry-api.version>
         <proj4j.version>1.1.5</proj4j.version>
     </properties>
-    <version>0.1.2${artifact.version.suffix}</version>
+    <version>0.1.5${artifact.version.suffix}</version>
     <name>dremio-udf-gis</name>
     <description>GIS UDF extensions for Dremio</description>
     <url>https://github.com/sheinbergon/dremio-udf-gis</url>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <esri-geometry-api.version>2.2.4</esri-geometry-api.version>
         <proj4j.version>1.1.5</proj4j.version>
     </properties>
-    <version>0.2.0${artifact.version.suffix}</version>
+    <version>0.2.1${artifact.version.suffix}</version>
     <name>dremio-udf-gis</name>
     <description>GIS UDF extensions for Dremio</description>
     <url>https://github.com/sheinbergon/dremio-udf-gis</url>

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>${checkstyle.version}</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STAsGeoJson.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STAsGeoJson.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STAsGeoJson.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STAsGeoJson.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 
@@ -44,9 +43,9 @@ public class STAsGeoJson implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput);
-    byte[] bytes = FunctionHelpersXL.toGeoJson(geom1);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeoJson(geom1);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, geoJsonOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, geoJsonOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STAsJson.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STAsJson.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STAsJson.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STAsJson.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 
@@ -44,9 +43,9 @@ public class STAsJson implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput);
-    byte[] bytes = FunctionHelpersXL.toJson(geom1);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toJson(geom1);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, jsonOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, jsonOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STAsText.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STAsText.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STAsText.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STAsText.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 
@@ -44,9 +43,9 @@ public class STAsText implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput);
-    byte[] bytes = FunctionHelpersXL.toText(geom1);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toText(geom1);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, wktOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, wktOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STBuffer.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STBuffer.java
@@ -22,7 +22,7 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import org.apache.arrow.memory.ArrowBuf;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
+
 
 import javax.inject.Inject;
 
@@ -47,10 +47,10 @@ public class STBuffer implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
     com.esri.core.geometry.ogc.OGCGeometry buffered = geom1.buffer(radiusInput.value);
-    byte[] bytes = FunctionHelpersXL.toBinary(buffered);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(buffered);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STBuffer.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STBuffer.java
@@ -22,6 +22,7 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import org.apache.arrow.memory.ArrowBuf;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STContains.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STContains.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Contains",
@@ -41,8 +40,8 @@ public class STContains implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.contains(geom2));
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.contains(geom2));
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STContains.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STContains.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Contains",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STCrosses.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STCrosses.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Crosses",
@@ -41,8 +40,8 @@ public class STCrosses implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.crosses(geom2));
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.crosses(geom2));
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STCrosses.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STCrosses.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Crosses",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDWithin.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDWithin.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_DWithin",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDWithin.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDWithin.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_DWithin",
@@ -45,8 +44,8 @@ public class STDWithin implements SimpleFunction {
 
   public void eval() {
     double distance = distanceInput.value;
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.distance(geom2) <= distance);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.distance(geom2) <= distance);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDifference.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDifference.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDifference.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDifference.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 
@@ -46,11 +45,11 @@ public class STDifference implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
     com.esri.core.geometry.ogc.OGCGeometry difference = geom1.difference(geom2);
-    byte[] bytes = FunctionHelpersXL.toBinary(difference);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(difference);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDisjoint.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDisjoint.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Disjoint",
@@ -41,9 +40,9 @@ public class STDisjoint implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
     boolean contains = geom1.disjoint(geom2);
-    output.value = FunctionHelpersXL.toBitValue(contains);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(contains);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDisjoint.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDisjoint.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Disjoint",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDistance.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDistance.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Distance",
@@ -41,8 +40,8 @@ public class STDistance implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
     output.value = geom1.distance(geom2);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STDistance.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STDistance.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Distance",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STEnvelope.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STEnvelope.java
@@ -22,7 +22,6 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCGeometry;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 
@@ -44,15 +43,15 @@ public class STEnvelope implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
     com.esri.core.geometry.ogc.OGCGeometry enveloped = envelope(geom1);
-    byte[] bytes = FunctionHelpersXL.toBinary(enveloped);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(enveloped);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 
   private OGCGeometry envelope(final OGCGeometry geometry) {
-    if (FunctionHelpersXL.isAPoint(geometry)) {
+    if (org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.isAPoint(geometry)) {
       return geometry;
     } else {
       return geometry.envelope();

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STEnvelope.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STEnvelope.java
@@ -22,6 +22,7 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCGeometry;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STEquals.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STEquals.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Equals",
@@ -41,8 +40,8 @@ public class STEquals implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.Equals(geom2));
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.Equals(geom2));
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STEquals.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STEquals.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Equals",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromText.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromText.java
@@ -43,9 +43,9 @@ public class STGeomFromText implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom = FunctionHelpersXL.toGeometry(wktInput);
-    byte[] bytes = FunctionHelpersXL.toBinary(geom);
+    com.esri.core.geometry.ogc.OGCGeometry geom = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(wktInput);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(geom);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromTextSrid.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromTextSrid.java
@@ -46,10 +46,10 @@ public class STGeomFromTextSrid implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom = FunctionHelpersXL.toGeometry(wktInput);
+    com.esri.core.geometry.ogc.OGCGeometry geom = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(wktInput);
     geom.setSpatialReference(com.esri.core.geometry.SpatialReference.create(sridInput.value));
-    byte[] bytes = FunctionHelpersXL.toBinary(geom);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(geom);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromWKB.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromWKB.java
@@ -43,9 +43,9 @@ public class STGeomFromWKB implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom = FunctionHelpersXL.toGeometry(wkbInput);
-    byte[] bytes = FunctionHelpersXL.toBinary(geom);
+    com.esri.core.geometry.ogc.OGCGeometry geom = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(wkbInput);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(geom);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromWKBSrid.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STGeomFromWKBSrid.java
@@ -46,10 +46,10 @@ public class STGeomFromWKBSrid implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom = FunctionHelpersXL.toGeometry(wkbInput);
+    com.esri.core.geometry.ogc.OGCGeometry geom = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(wkbInput);
     geom.setSpatialReference(com.esri.core.geometry.SpatialReference.create(sridInput.value));
-    byte[] bytes = FunctionHelpersXL.toBinary(geom);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(geom);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STIntersects.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STIntersects.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Intersects",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STIntersects.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STIntersects.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Intersects",
@@ -44,8 +43,8 @@ public class STIntersects implements SimpleFunction {
 
   @Override
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.intersects(geom2));
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.intersects(geom2));
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STOverlaps.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STOverlaps.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(name = "ST_Overlaps", scope = FunctionTemplate.FunctionScope.SIMPLE,
     nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STOverlaps.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STOverlaps.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(name = "ST_Overlaps", scope = FunctionTemplate.FunctionScope.SIMPLE,
     nulls = FunctionTemplate.NullHandling.NULL_IF_NULL)
@@ -39,9 +38,9 @@ public class STOverlaps implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
     boolean contains = geom1.overlaps(geom2);
-    output.value = FunctionHelpersXL.toBitValue(contains);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(contains);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STPoint.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STPoint.java
@@ -22,7 +22,6 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import org.apache.arrow.memory.ArrowBuf;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 
@@ -56,16 +55,16 @@ public class STPoint implements SimpleFunction {
     com.esri.core.geometry.SpatialReference srid = com.esri.core.geometry.SpatialReference.create(srid());
     com.esri.core.geometry.Point point = new com.esri.core.geometry.Point(longitude, latitude);
     com.esri.core.geometry.ogc.OGCPoint geometry = new com.esri.core.geometry.ogc.OGCPoint(point, srid);
-    byte[] bytes = FunctionHelpersXL.toBinary(geometry);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(geometry);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, output);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, output);
   }
 
   private int srid() {
-    if (FunctionHelpersXL.isHolderSet(sridInput)) {
+    if (org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.isHolderSet(sridInput)) {
       return sridInput.value;
     } else {
-      return FunctionHelpersXL.DEFAULT_SRID;
+      return org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.DEFAULT_SRID;
     }
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STPoint.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STPoint.java
@@ -22,6 +22,7 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import org.apache.arrow.memory.ArrowBuf;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STRelate.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STRelate.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Relate",
@@ -46,9 +45,9 @@ public class STRelate implements SimpleFunction {
 
   @Override
   public void eval() {
-    java.lang.String matrix = FunctionHelpersXL.toUTF8String(matrixParam);
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.relate(geom2, matrix));
+    java.lang.String matrix = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toUTF8String(matrixParam);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.relate(geom2, matrix));
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STRelate.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STRelate.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Relate",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STTouches.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STTouches.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Touches",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STTouches.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STTouches.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Touches",
@@ -41,8 +40,8 @@ public class STTouches implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.touches(geom2));
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.touches(geom2));
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STTransform.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STTransform.java
@@ -23,6 +23,7 @@ import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.dremio.exec.expr.annotations.Workspace;
 import com.esri.core.geometry.VertexGeometryAccessor;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STTransform.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STTransform.java
@@ -23,7 +23,6 @@ import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.dremio.exec.expr.annotations.Workspace;
 import com.esri.core.geometry.VertexGeometryAccessor;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
@@ -70,13 +69,13 @@ public class STTransform implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom = FunctionHelpersXL.toGeometry(binaryInput);
+    com.esri.core.geometry.ogc.OGCGeometry geom = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
     org.locationtech.proj4j.ProjCoordinate target = new org.locationtech.proj4j.ProjCoordinate();
     com.esri.core.geometry.SpatialReference targetSridReference = com.esri.core.geometry.SpatialReference.create(targetSrid);
     com.esri.core.geometry.ogc.OGCGeometry transformed = transformGeometry(geom, target, targetSridReference);
-    byte[] bytes = FunctionHelpersXL.toBinary(transformed);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(transformed);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
 
   }
 
@@ -84,7 +83,7 @@ public class STTransform implements SimpleFunction {
       final @Nonnull com.esri.core.geometry.ogc.OGCGeometry geometry,
       final @Nonnull org.locationtech.proj4j.ProjCoordinate to,
       final @Nonnull com.esri.core.geometry.SpatialReference srid) {
-    if (FunctionHelpersXL.isAPoint(geometry)) {
+    if (org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.isAPoint(geometry)) {
       return transform((com.esri.core.geometry.ogc.OGCPoint) geometry, to, srid);
     } else {
       return transform(geometry, to, srid);

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STUnion.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STUnion.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STUnion.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STUnion.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.inject.Inject;
 
@@ -46,11 +45,11 @@ public class STUnion implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
     com.esri.core.geometry.ogc.OGCGeometry union = geom1.union(geom2);
-    byte[] bytes = FunctionHelpersXL.toBinary(union);
+    byte[] bytes = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBinary(union);
     buffer = buffer.reallocIfNeeded(bytes.length);
-    FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.populate(bytes, buffer, binaryOutput);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STWithin.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STWithin.java
@@ -21,6 +21,7 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Within",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STWithin.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STWithin.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_Within",
@@ -41,8 +40,8 @@ public class STWithin implements SimpleFunction {
   }
 
   public void eval() {
-    com.esri.core.geometry.ogc.OGCGeometry geom1 = FunctionHelpersXL.toGeometry(binaryInput1);
-    com.esri.core.geometry.ogc.OGCGeometry geom2 = FunctionHelpersXL.toGeometry(binaryInput2);
-    output.value = FunctionHelpersXL.toBitValue(geom1.within(geom2));
+    com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput1);
+    com.esri.core.geometry.ogc.OGCGeometry geom2 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput2);
+    output.value = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toBitValue(geom1.within(geom2));
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STX.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STX.java
@@ -22,8 +22,6 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 
-import javax.annotation.Nullable;
-
 @FunctionTemplate(
     name = "ST_X",
     scope = FunctionTemplate.FunctionScope.SIMPLE,
@@ -33,21 +31,13 @@ public class STX implements SimpleFunction {
   org.apache.arrow.vector.holders.NullableVarBinaryHolder binaryInput;
 
   @Output
-  org.apache.arrow.vector.holders.Float8Holder output;
+  org.apache.arrow.vector.holders.NullableFloat8Holder output;
 
   public void setup() {
   }
 
   public void eval() {
     com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
-    output.value = x(geom1);
-  }
-
-  private double x(@Nullable final com.esri.core.geometry.ogc.OGCGeometry geometry) {
-    if (org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.isAPoint(geometry)) {
-      return ((com.esri.core.geometry.ogc.OGCPoint) geometry).X();
-    } else {
-      return Double.NaN;
-    }
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.extractX(geom1, output);
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STX.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STX.java
@@ -22,6 +22,7 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCPoint;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STXMax.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STXMax.java
@@ -23,6 +23,7 @@ import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCPoint;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_XMax",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STXMin.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STXMin.java
@@ -23,6 +23,7 @@ import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCPoint;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_XMin",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STY.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STY.java
@@ -21,7 +21,6 @@ import com.dremio.exec.expr.SimpleFunction;
 import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
-import com.esri.core.geometry.ogc.OGCPoint;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STY.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STY.java
@@ -22,6 +22,7 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCPoint;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 import javax.annotation.Nullable;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STY.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STY.java
@@ -22,8 +22,6 @@ import com.dremio.exec.expr.annotations.FunctionTemplate;
 import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 
-import javax.annotation.Nullable;
-
 @FunctionTemplate(
     name = "ST_Y",
     scope = FunctionTemplate.FunctionScope.SIMPLE,
@@ -33,21 +31,14 @@ public class STY implements SimpleFunction {
   org.apache.arrow.vector.holders.NullableVarBinaryHolder binaryInput;
 
   @Output
-  org.apache.arrow.vector.holders.Float8Holder output;
+  org.apache.arrow.vector.holders.NullableFloat8Holder output;
 
   public void setup() {
   }
 
   public void eval() {
     com.esri.core.geometry.ogc.OGCGeometry geom1 = org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.toGeometry(binaryInput);
-    output.value = y(geom1);
+    org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.extractY(geom1, output);
   }
 
-  private double y(@Nullable final com.esri.core.geometry.ogc.OGCGeometry geometry) {
-    if (org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL.isAPoint(geometry)) {
-      return ((com.esri.core.geometry.ogc.OGCPoint) geometry).Y();
-    } else {
-      return Double.NaN;
-    }
-  }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STYMax.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STYMax.java
@@ -23,6 +23,7 @@ import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCPoint;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_YMax",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/STYMin.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/STYMin.java
@@ -23,6 +23,7 @@ import com.dremio.exec.expr.annotations.Output;
 import com.dremio.exec.expr.annotations.Param;
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.esri.core.geometry.ogc.OGCPoint;
+import org.sheinbergon.dremio.udf.gis.util.FunctionHelpersXL;
 
 @FunctionTemplate(
     name = "ST_YMin",

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/util/FunctionHelpersXL.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/util/FunctionHelpersXL.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.sheinbergon.dremio.udf.gis;
+package org.sheinbergon.dremio.udf.gis.util;
 
 import com.esri.core.geometry.Envelope;
 

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/util/FunctionHelpersXL.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/util/FunctionHelpersXL.java
@@ -27,10 +27,10 @@ public final class FunctionHelpersXL {
   static final int BIT_TRUE = 1;
   static final int BIT_FALSE = 0;
   static final String POINT = "Point";
-  static final int DEFAULT_SRID = 4326;
+  public static final int DEFAULT_SRID = 4326;
 
 
-  static java.lang.String toUTF8String(
+  public static java.lang.String toUTF8String(
       final @Nonnull org.apache.arrow.vector.holders.VarCharHolder holder) {
     return com.dremio.exec.expr.fn.impl.StringFunctionHelpers.toStringFromUTF8(
         holder.start,

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/util/FunctionHelpersXL.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/util/FunctionHelpersXL.java
@@ -18,6 +18,7 @@
 package org.sheinbergon.dremio.udf.gis.util;
 
 import com.esri.core.geometry.Envelope;
+import org.apache.arrow.vector.holders.NullableFloat8Holder;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -126,6 +127,28 @@ public final class FunctionHelpersXL {
       throw new java.lang.IllegalArgumentException(
           java.lang.String.format("Unsupported value holder type - %s",
               holder.getClass().getName()));
+    }
+  }
+
+  public static void extractY(
+      @Nullable final com.esri.core.geometry.ogc.OGCGeometry geometry,
+      @Nonnull final NullableFloat8Holder output) {
+    if (isAPoint(geometry)) {
+      output.value = ((com.esri.core.geometry.ogc.OGCPoint) geometry).Y();
+      output.isSet = BIT_TRUE;
+    } else {
+      output.isSet = BIT_FALSE;
+    }
+  }
+
+  public static void extractX(
+      @Nullable final com.esri.core.geometry.ogc.OGCGeometry geometry,
+      @Nonnull final NullableFloat8Holder output) {
+    if (isAPoint(geometry)) {
+      output.value = ((com.esri.core.geometry.ogc.OGCPoint) geometry).X();
+      output.isSet = BIT_TRUE;
+    } else {
+      output.isSet = BIT_FALSE;
     }
   }
 }

--- a/src/main/java/org/sheinbergon/dremio/udf/gis/util/package-info.java
+++ b/src/main/java/org/sheinbergon/dremio/udf/gis/util/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Dremio GIS extension common utilities
+ *
+ * @author sheinbergon
+ * @since 0.1.5
+ */
+package org.sheinbergon.dremio.udf.gis.util;
+


### PR DESCRIPTION
- Address issues brought up in #6  and #5 
- Solve compilation errors for ST_X and ST_Y
- Compilation target lowered to Java 8
- Upgrade checkstyle version
-  Add `ST_GeomFromWKB` to support `WKB` decoding ( simplify queries from remote sources)